### PR TITLE
Productive ERROR fixed and static.css for HTML pages

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,2 +1,3 @@
+BASE_URL=https://rahmenabkommen-gpt.ch
 OPENAI_API_KEY=
 HUGGINGFACEHUB_API_TOKEN=

--- a/api/app/chains/prompt_template.py
+++ b/api/app/chains/prompt_template.py
@@ -22,6 +22,16 @@ def get_prompt_template():
     return ChatPromptTemplate.from_messages([
         SystemMessagePromptTemplate.from_template(system_message.strip()),
         HumanMessagePromptTemplate.from_template(
-            "Verträge:\n{document.page_content}\n\nQuelle: {document.metadata.source}"
+            "{question}"
         )
     ])
+
+# TODO: Das scheint nicht zu gehen und führt zu produktiven Fehler, wenn nach der Erstfrage eine 
+# Zweite im Chatverlauf gestellt wird. Die Referenzen scheinen auch nicht zu funktionieren:
+# Frage mal "Wie wird die Streitbeteiligung geregelt?" und klicke auf die Referenz [1].
+#    return ChatPromptTemplate.from_messages([
+#        SystemMessagePromptTemplate.from_template(system_message.strip()),
+#        HumanMessagePromptTemplate.from_template(
+#            "Verträge:\n{document.page_content}\n\nQuelle: {document.metadata.source}"
+#        )
+#    ])

--- a/api/app/services/chat_service.py
+++ b/api/app/services/chat_service.py
@@ -28,8 +28,8 @@ class DefaultSourceRetriever(BaseRetriever):
     class Config:
         arbitrary_types_allowed = True
 
-    def __init__(self, retriever: BaseRetriever):
-        super().__init__(retriever=retriever)
+    def __init__(self, retriever: BaseRetriever, **kwargs):
+        super().__init__(retriever=retriever, **kwargs)
 
     def _get_relevant_documents(self, query: str, **kwargs) -> List[Document]:
         docs = self.retriever.get_relevant_documents(query, **kwargs)

--- a/api/bin/setup.sh
+++ b/api/bin/setup.sh
@@ -50,7 +50,7 @@ pip install --upgrade pip wheel setuptools
 pip install -r requirements.txt
 
 # Optional explicit installs if missing from requirements.txt:
-pip install flask flask-cors flask-sqlalchemy flask-migrate python-dotenv
+pip install flask flask-cors flask-sqlalchemy flask-migrate python-dotenv pymupdf
 
 echo "✅ All requirements and core packages installed."
 

--- a/api/vector/preprocess.py
+++ b/api/vector/preprocess.py
@@ -8,7 +8,11 @@ from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from sentence_transformers import SentenceTransformer
 from langchain_community.embeddings import SentenceTransformerEmbeddings
+from dotenv import load_dotenv
 
+load_dotenv()  # .env laden
+
+BASE_URL = os.getenv("BASE_URL", "https://rahmenabkommen-gpt.ch")  # Fallback-URL
 PDF_DIR = "./app/data/pdfs"
 HTML_DIR = "../ui/public/contracts"
 FAISS_INDEX_PATH = "./app/data/vectorstore_index"
@@ -19,11 +23,16 @@ def pdf_to_html(pdf_path, out_dir):
     und schreibt ein HTML-Dokument mit <h1>, <h2> und <p> Elementen.
     """
     doc = fitz.open(pdf_path)
-    html = BeautifulSoup("<!DOCTYPE html><html><head>"
-                         f"<meta charset='utf-8'><title>{Path(pdf_path).stem}</title>"
-                         "</head><body></body></html>",
-                         "html.parser")
+    html = BeautifulSoup(
+        f"<!DOCTYPE html><html><head>"
+        f"<meta charset='utf-8'><title>{Path(pdf_path).stem}</title>"
+        f"<link rel='stylesheet' href='{BASE_URL}/static.css'>"
+        "</head><body></body></html>",
+        "html.parser"
+    )    
+
     body = html.body
+    
     # ID-Counter für Referenzen
     counters = {"h1": 0, "h2": 0, "p": 0}
 
@@ -135,7 +144,7 @@ def build_and_save_vectorstore(pdf_dir, html_dir, output_path):
         for chunk, start_pos in zip(chunks, positions):
             for map_start, map_end, element_id in mapping:
                 if map_start <= start_pos < map_end:
-                    metadata = {"source": f"https://rahmenabkommen-gpt.ch/contracts/{Path(pdf_path).stem}.html#{element_id}"}
+                    metadata = {"source": f"{BASE_URL}/contracts/{Path(pdf_path).stem}.html#{element_id}"}
                     all_chunk_texts.append(chunk)
                     all_metadatas.append(metadata)
                     break

--- a/ui/app/lib/meta.ts
+++ b/ui/app/lib/meta.ts
@@ -4,7 +4,7 @@ const defaultImage = `${frontendUrl}/rich-preview.png`;
 
 export function buildMeta({
   // Default meta content
-  title = 'Stelle deine Fragen an das Rahmenabkommen zwischen der Schweiz und der EU.',
+  title = 'Rahmenabkommen GPT',
   description = 'Stelle deine Fragen zum Rahmenabkommen zwischen der Schweiz und der EU.',
   image = defaultImage,
   url = frontendUrl,

--- a/ui/public/static.css
+++ b/ui/public/static.css
@@ -1,0 +1,68 @@
+html, body {
+  font-family: ui-sans-serif, system-ui, sans-serif, 
+               "Apple Color Emoji", "Segoe UI Emoji", 
+               "Segoe UI Symbol", "Noto Color Emoji";
+  background-color: #f3f4f6;
+  color: #222;
+  margin: 2rem;
+  padding: 0;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+  color: #111;
+}
+
+h1 {
+  font-size: 2rem;
+  border-bottom: 2px solid #ddd;
+  padding-bottom: 0.2em;
+}
+
+h2 {
+  font-size: 1.5rem;
+  color: #333;
+}
+
+p {
+  margin: 0.5em 0 1em 0;
+}
+
+a {
+  color: #0066cc;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family: monospace;
+  background-color: #f4f4f4;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  html, body {
+    background-color: #030712;
+    color: #eee;
+  }
+
+  h1, h2 {
+    color: #fff;
+  }
+
+  a {
+    color: #66aaff;
+  }
+
+  code {
+    background-color: #333;
+  }
+}


### PR DESCRIPTION
- api/.env: BASE_UTR added, if none is defined, the default productive is taken
- api/app/chains/prompt_template: Productive ERROR fixed, but NEEDS re-work, see comment in file!
- api/app/services/chat_service.py: BaseRetriever can take more arguments in future
- api/bin/setup.sh: package pymupdf added
- api/vector/preprocess.py: static.css reference for HTML pages / hard-coded URL replaced
- ui/app/lib/meta.ts: As title "Rahmenabkommen GPT" is correct, not repeating the description, this is in align with conversations title and OpenGraph previews; better that way, otherwise in OG's the description is shown twice instead a title and a description
- ui/public/static.css: Simple CSS fro HTML pages; server dark or light mode based on OS settings